### PR TITLE
Add stats only mode

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "balsama/drupalorg-dom-parser",
-    "description": "Scraps statistics about projects on Drupal.org",
+    "description": "Scrapes statistics about projects on Drupal.org",
     "type": "library",
     "require": {
         "paquettg/php-html-parser": "^1.7.0"
@@ -16,6 +16,7 @@
         }
     ],
     "minimum-stability": "dev",
+    "prefer-stable": true,
     "autoload": {
         "psr-4": {
             "Balsama\\DrupalOrgProject\\": "src"

--- a/src/Stats.php
+++ b/src/Stats.php
@@ -45,6 +45,7 @@ class Stats {
      */
     private function fetchDom($project_name) {
         $dom = new Dom;
+        $dom->setOptions(['cleanupInput' => false]);
         $this->dom = $dom->loadFromUrl('https://www.drupal.org/project/' . $project_name);
         return $this->dom;
     }
@@ -97,14 +98,16 @@ class Stats {
      * @param $project_name
      *   The machine name of a Drupal.org project.
      */
-    public function __construct($project_name) {
-        $dom = $this->fetchDom($project_name);
-        $this->setDom($dom);
+    public function __construct($project_name, $statsOnly = false) {
+        if ($statsOnly === false) {
+            $dom = $this->fetchDom($project_name);
+            $this->setDom($dom);
+        }
         $stats_dom = $this->fetchStatsDom($project_name);
         $this->setStatsDom($stats_dom);
         $all_project_usage = $this->fetchAllProjectUsage();
         $this->setAllProjectUsage($all_project_usage);
-        if (($project_name != 'drupal') && ($project_name != 'imce_wysiwyg')) {
+        if ($statsOnly === false && ($project_name != 'drupal') && ($project_name != 'imce_wysiwyg')) {
             // Main drupal project has a different project page than other
             // projects so we can't parse it the same way. imce_wysiwyg also
             // seems to be be different somehow. I'm not troubleshooting what
@@ -255,10 +258,13 @@ class Stats {
      */
     private function getCurrentNthUsage($nth) {
         $all_project_usage = $this->all_project_usage;
-        if (!isset($all_project_usage[0][$nth])) {
-            return 0;
+        // Sometimes the current week erroneously reports 0's so go to the next.
+        foreach ([0,1] as $row) {
+            if (!empty(intval($all_project_usage[$row][$nth]))) {
+                return intval(str_replace(',', '', $all_project_usage[$row][$nth]));
+            }
         }
-        return intval(str_replace(',', '', $all_project_usage[0][$nth]));
+        return 0;
     }
 
     /**

--- a/src/Stats.php
+++ b/src/Stats.php
@@ -261,7 +261,7 @@ class Stats {
     private function getCurrentNthUsage($nth) {
         $all_project_usage = $this->all_project_usage;
         // Sometimes the current week erroneously reports 0's so go to the next.
-        foreach ([0,1] as $row) {
+        for ($row = 0; $row < count($all_project_usage) && $row <= 1; $row++) {
             if (!empty(intval($all_project_usage[$row][$nth]))) {
                 return intval(str_replace(',', '', $all_project_usage[$row][$nth]));
             }

--- a/src/Stats.php
+++ b/src/Stats.php
@@ -187,14 +187,16 @@ class Stats {
      *   Rows of the specified project's usage statistic table.
      */
     private function fetchAllProjectUsage() {
+        $stat = [];
         $stats_dom = $this->stats_dom;
         $stat_cols = $stats_dom->find('#project-usage-project-api thead tr', 0);
-        $cols = count($stat_cols);
-        $highest_release = substr($stat_cols->find('.project-usage-numbers', ($cols - 4))->innerHtml(), 0, 2);
-        $stat_rows = $stats_dom->find('#project-usage-project-api tbody tr');
-        $stat = [];
-        foreach ($stat_rows as $stat_row) {
-            $stat[] = $this->statRowProcess($stat_row, $highest_release);
+        if ($stat_cols !== null) {
+            $cols = count($stat_cols);
+            $highest_release = substr($stat_cols->find('.project-usage-numbers', ($cols - 4))->innerHtml(), 0, 2);
+            $stat_rows = $stats_dom->find('#project-usage-project-api tbody tr');
+            foreach ($stat_rows as $stat_row) {
+                $stat[] = $this->statRowProcess($stat_row, $highest_release);
+            }
         }
         return $stat;
     }

--- a/src/Stats.php
+++ b/src/Stats.php
@@ -262,7 +262,8 @@ class Stats {
         $all_project_usage = $this->all_project_usage;
         // Sometimes the current week erroneously reports 0's so go to the next.
         for ($row = 0; $row < count($all_project_usage) && $row <= 1; $row++) {
-            if (!empty(intval($all_project_usage[$row][$nth]))) {
+            if (isset($all_project_usage[$row][$nth]) &&
+                !empty(intval($all_project_usage[$row][$nth]))) {
                 return intval(str_replace(',', '', $all_project_usage[$row][$nth]));
             }
         }

--- a/tests/StatsTest.php
+++ b/tests/StatsTest.php
@@ -26,31 +26,31 @@ class StatsTest extends PHPUnit_Framework_TestCase {
     public function testUsageStatistics() {
         // Project with two columns; 7.x & 8.x.
         $project_name = 'metatag';
-        $project = new Stats($project_name);
+        $project = new Stats($project_name, true);
 
         $usage = $project->getCurrentD8Usage();
         $this->assertInternalType('int', $usage);
-        $this->assertTrue($usage > 12000);
-        $this->assertTrue($usage < 20000);
+        $this->assertTrue($usage > 20000);
+        $this->assertTrue($usage < 2000000);
 
         $d7usage = $project->getCurrentD7Usage();
         $this->assertInternalType('int', $d7usage);
         $this->assertTrue($d7usage > 290000);
-        $this->assertTrue($d7usage < 340000);
+        $this->assertTrue($d7usage < 2000000);
 
         // Project with four columns; 5.x, 6.x, 7.x, & 8.x.
         $project_name = 'pathauto';
-        $project = new Stats($project_name);
+        $project = new Stats($project_name, true);
 
         $usage = $project->getCurrentD8Usage();
         $this->assertInternalType('int', $usage);
         $this->assertTrue($usage > 19000);
-        $this->assertTrue($usage < 40000);
+        $this->assertTrue($usage < 2000000);
 
         $d7usage = $project->getCurrentD7Usage();
         $this->assertInternalType('int', $d7usage);
         $this->assertTrue($d7usage > 600000);
-        $this->assertTrue($d7usage < 670000);
+        $this->assertTrue($d7usage < 2000000);
     }
 
     /**


### PR DESCRIPTION
There's an issue with `paquettg/php-html-parser` that's causing it to fail pretty badly on the project pages. Lots of issues have been filed about it. Fortunately, it's parsing the usage page okay which is the one I care about anyway. I added a parameter to specify it should only do the usage page. This prevents Stats::__construct() from throwing exceptions (yay) and also makes it run 2x as fast.